### PR TITLE
Add tRPC router tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,10 +8,11 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "fastify": "^4.26.2",
-    "@trpc/server": "^10.45.0",
     "@auth/core": "^0.40.0",
-    "drizzle-orm": "^0.30.6"
+    "@trpc/server": "^10.45.0",
+    "drizzle-orm": "^0.30.6",
+    "fastify": "^4.26.2",
+    "zod": "^3.25.67"
   },
   "devDependencies": {
     "tsx": "^4.7.0",

--- a/backend/tests/router.test.ts
+++ b/backend/tests/router.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import Fastify from 'fastify'
+import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify'
+import { InMemoryDB } from '../src/infrastructure/db'
+import { UserService } from '../src/usecases/userService'
+import { createRouter } from '../src/trpc/router'
+
+const setup = async () => {
+  const app = Fastify()
+  const db = new InMemoryDB()
+  const service = new UserService(db)
+  const router = createRouter(service)
+  app.register(fastifyTRPCPlugin, {
+    prefix: '/trpc',
+    trpcOptions: { router }
+  })
+  await app.ready()
+  return { app, db }
+}
+
+describe('tRPC router via Fastify', () => {
+  it('lists users', async () => {
+    const { app } = await setup()
+    const res = await app.inject({ method: 'GET', url: '/trpc/users' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.payload)
+    expect(body.result.data).toEqual([])
+  })
+
+  it('creates a new user', async () => {
+    const { app } = await setup()
+    const resCreate = await app.inject({
+      method: 'POST',
+      url: '/trpc/createUser',
+      payload: JSON.stringify({ name: 'Charlie' }),
+      headers: { 'content-type': 'application/json' }
+    })
+    expect(resCreate.statusCode).toBe(200)
+    const created = JSON.parse(resCreate.payload).result.data
+    expect(created.name).toBe('Charlie')
+
+    const resList = await app.inject({ method: 'GET', url: '/trpc/users' })
+    expect(JSON.parse(resList.payload).result.data).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add `router.test.ts` to exercise tRPC endpoints via Fastify
- install `zod` for router validation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d12b463c08329bfd851face4f0c48