### PR TITLE
Add dotenv and document env handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,25 @@ pnpm --filter backend run dev    # start API
 pnpm --filter frontend run dev   # start frontend
 ```
 
+The backend will load variables from `backend/.env` when running in development.
+
 To run the tests:
 
 ```bash
 pnpm --filter backend test
 pnpm --filter frontend test
 ```
+
+### Environment variables
+
+The backend reads configuration from environment variables using [dotenv](https://github.com/motdotla/dotenv). A sample file is available at `backend/.env.example`.
+Copy it to `backend/.env` and adjust values if needed:
+
+```bash
+cp backend/.env.example backend/.env
+```
+
+When running with Docker Compose, you can define variables using the `environment` section of `docker-compose.yml` or by providing a `.env` file that Docker Compose will read automatically.
 
 ### Docker
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables for the backend
+PORT=3000

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,10 +8,11 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "fastify": "^4.26.2",
-    "@trpc/server": "^10.45.0",
     "@auth/core": "^0.40.0",
-    "drizzle-orm": "^0.30.6"
+    "@trpc/server": "^10.45.0",
+    "dotenv": "^16.5.0",
+    "drizzle-orm": "^0.30.6",
+    "fastify": "^4.26.2"
   },
   "devDependencies": {
     "tsx": "^4.7.0",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,4 +1,7 @@
 import Fastify from 'fastify'
+import dotenv from 'dotenv'
+
+dotenv.config()
 import { createFastifyTRPCPlugin } from '@trpc/server/adapters/fastify'
 import { createRouter } from './trpc/router'
 import { InMemoryDB } from './infrastructure/db'
@@ -23,10 +26,10 @@ server.register(createFastifyTRPCPlugin, {
 
 server.get('/', async () => ({ status: 'ok' }))
 
-server.listen({ port: 3000 }, err => {
+server.listen({ port: Number(process.env.PORT || 3000) }, err => {
   if (err) {
     server.log.error(err)
     process.exit(1)
   }
-  server.log.info('server running at http://localhost:3000')
+  server.log.info(`server running at http://localhost:${process.env.PORT || 3000}`)
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@trpc/server':
         specifier: ^10.45.0
         version: 10.45.2
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.5.0
       drizzle-orm:
         specifier: ^0.30.6
         version: 0.30.10


### PR DESCRIPTION
## Summary
- install `dotenv` in backend
- load environment from `.env` in `backend/src/main.ts`
- support custom PORT through env var
- provide `backend/.env.example`
- document environment variables in README

## Testing
- `pnpm --filter backend test`
- `pnpm --filter frontend... test`


------
https://chatgpt.com/codex/tasks/task_e_685d12bdf8148329af8c86c951a70a8f